### PR TITLE
Return data in easily parsable json format

### DIFF
--- a/server/src/storage/cell.rs
+++ b/server/src/storage/cell.rs
@@ -9,7 +9,7 @@ const TAG_F64 : u8 = 2;
 const TAG_STR : u8 = 3;
 const TAG_BOOL : u8 = 4;
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Cell {
     Int(i64),
     Float(f64),
@@ -101,5 +101,18 @@ impl Cell {
             Cell::Int(val) => Some(val),
             _ => None
         }
+    }
+}
+
+impl Serialize for Cell {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer {
+            match self {
+                Cell::Int(val) => serializer.serialize_i64(val.to_owned()),
+                Cell::Float(val) => serializer.serialize_f64(val.to_owned()),
+                Cell::String(str) => serializer.serialize_str(&str),
+                Cell::Boolean(bool) => serializer.serialize_bool(bool.to_owned()),
+            }
     }
 }

--- a/server/src/storage/column_frame.rs
+++ b/server/src/storage/column_frame.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Serialize;
 
 use super::cell::Cell;
@@ -29,5 +31,16 @@ impl ColumnFrame {
         else {
             None
         }
+    }
+
+    pub fn to_view_object(&self) -> HashMap<String, Cell> {
+        let mut map = HashMap::new();
+        for i in 0..self.column_names.len() {
+            let column = self.column_names[i].to_owned();
+            let column_value = self.column_values[i].to_owned();
+            map.insert(column, column_value);
+        }
+
+        map
     }
 }

--- a/server/src/web.rs
+++ b/server/src/web.rs
@@ -1,11 +1,11 @@
-use crate::command::Command;
+use crate::{command::Command, storage::cell::Cell};
 use crate::query::wasm_error::WasmError;
 use bytes::BufMut;
 use futures::TryStreamExt;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use tokio::sync::oneshot;
-use std::convert::Infallible;
+use std::{convert::Infallible, collections::HashMap};
 use tracing::error;
 use warp::multipart::{FormData, Part};
 
@@ -219,6 +219,7 @@ async fn execute_map_fn(
             Ok(rows) => {
                 // TODO: Convert column frames into something that's easy to print
                 // and readable
+                let rows : Vec<HashMap<String, Cell>> = rows.iter().map(|r| r.to_view_object()).collect();
                 let json = warp::reply::json(&rows);
                 return Ok(warp::reply::with_status(json, StatusCode::OK));
             }


### PR DESCRIPTION
This PR ships with an update that improves the usability and readability of data returned by the `/query` endpoint.

We had a data format that looked like this before:

```
───────┬─────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼─────────────────────────────────────────────────────────────────────────────────────────
   1   │ [
   2   │   {
   3   │     "column_names": [
   4   │       "id",
   5   │       "url",
   6   │       "title",
   7   │       "points",
   8   │       "timestamp"
   9   │     ],
  10   │     "column_values": [
  11   │       {
  12   │         "Int": 1
  13   │       },
  14   │       {
  15   │         "String": "https://forums.macrumors.com/threads/shiny-areas-on-macbook-keyboard-
       │ oil-or-matt-surface-rubbing-away.2326404/"
  16   │       },
  17   │       {
  18   │         "String": "I'm particularly crazy about keyboard cleanliness"
  19   │       },
  20   │       {
  21   │         "Int": 2
  22   │       },
  23   │       {
  24   │         "Int": 1677816218
  25   │       }
  26   │     ]
  27   │   },
```
While this data format was very descriptive in terms of type information, it also makes it challenging for clients to consume the output.

With this PR, we now ship a data format that looks like this:

```
───────┬─────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼─────────────────────────────────────────────────────────────────────────────────────────
   1   │ [
   2   │   {
   3   │     "url": "https://forums.macrumors.com/threads/shiny-areas-on-macbook-keyboard-oil-or-
       │ matt-surface-rubbing-away.2326404/",
   4   │     "points": 2,
   5   │     "id": 1,
   6   │     "title": "I'm particularly crazy about keyboard cleanliness",
   7   │     "timestamp": 1677816218
   8   │   },
   9   │   {
  10   │     "url": "https://www.honeybadger.io/blog/ractors/",
  11   │     "id": 2,
  12   │     "timestamp": 1677816218,
  13   │     "title": "A Beginner's Guide to Ractors in Ruby",
  14   │     "points": 2
  15   │   },
  16   │   {
  17   │     "id": 3,
  18   │     "title": "Litestack: A Ruby gem that provides an all-in-one solution for web applica
       │ tion",
  19   │     "url": "https://github.com/oldmoe/litestack",
  20   │     "points": 1,
  21   │     "timestamp": 1677816218
  22   │   },
```

This format is much more concise and easier to read. Additionally, it is also less dependent on internal data representation, specifically the `Cell` struct.